### PR TITLE
fix rgdal travis error

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,8 +24,9 @@ Imports:
   tibble,
   jsonlite,
   geojsonio,
-  rmapshaper,
-  rgdal
+  rmapshaper
+Remotes: 
+    cran/rgdal@1.3.9
 Suggests: 
     testthat,
     shinytest,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,6 +12,8 @@ LazyData: true
 RoxygenNote: 6.1.1
 BugReports: https://github.com/Helseatlas/shinymap/issues
 URL: https://helseatlas.github.io/shinymap
+Remotes: 
+    cran/rgdal@1.3-9
 Imports:
   shiny,
   sp,
@@ -24,9 +26,8 @@ Imports:
   tibble,
   jsonlite,
   geojsonio,
-  rmapshaper
-Remotes: 
-    cran/rgdal@1.3-9
+  rmapshaper,
+  rgdal
 Suggests: 
     testthat,
     shinytest,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Imports:
   geojsonio,
   rmapshaper
 Remotes: 
-    cran/rgdal@1.3.9
+    cran/rgdal@1.3-9
 Suggests: 
     testthat,
     shinytest,


### PR DESCRIPTION
Not able to build the newest version of rgdal on travis (1.4.2).

Tried this solution: https://travis-ci.community/t/travis-build-ignoring-r-package-version-in-description/2431

Stackoverflow: https://stackoverflow.com/questions/55126857/resolve-rgdal-package-failing-on-travis-build

