### PR TITLE
rm xml2 and covr from DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,6 +29,4 @@ Imports:
   rgdal
 Suggests: 
     testthat,
-    shinytest,
-    xml2,
-    covr
+    shinytest


### PR DESCRIPTION
Do not remember why we needed xml2. covr is only used by travis