### PR TITLE
rm unused packages in DESCRIPTION file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,18 +29,18 @@ env:
   global:
     - _R_CHECK_TESTS_NLINES_=0
 
-addons:
-  apt:
-    packages:
-      - libcurl4-gnutls-dev
-      - libgit2-dev
-      - libssl-dev
-      - libudunits2-dev
-      - libprotobuf-dev
-      - libv8-dev
-      - libjq-dev
-      - protobuf-compiler
-      - libgdal-dev
+#addons:
+#  apt:
+#    packages:
+#      - libcurl4-gnutls-dev
+#      - libgit2-dev
+#      - libssl-dev
+#      - libudunits2-dev
+#      - libprotobuf-dev
+#      - libv8-dev
+#      - libjq-dev
+#      - protobuf-compiler
+#      - libgdal-dev
 
 r_packages:
   - covr

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,19 +29,6 @@ env:
   global:
     - _R_CHECK_TESTS_NLINES_=0
 
-#addons:
-#  apt:
-#    packages:
-#      - libcurl4-gnutls-dev
-#      - libgit2-dev
-#      - libssl-dev
-#      - libudunits2-dev
-#      - libprotobuf-dev
-#      - libv8-dev
-#      - libjq-dev
-#      - protobuf-compiler
-#      - libgdal-dev
-
 r_packages:
   - covr
   - lintr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,16 +15,12 @@ URL: https://helseatlas.github.io/shinymap
 Imports:
   shiny,
   shinythemes,
-  sp,
   rsconnect,
   ggplot2,
   leaflet,
   magrittr,
   dplyr,
   ggthemes,
-  geojsonio,
-  rmapshaper,
-  rgdal,
   classInt
 Suggests: 
     testthat,

--- a/tests/testthat/test_make_map.R
+++ b/tests/testthat/test_make_map.R
@@ -9,7 +9,6 @@ test_that("make_map returns error if type is unknown", {
 })
 
 test_that("make_map returns error if type is unknown and map is given", {
-  testmap <- geojsonio::geojson_read("data/test.geojson", what = "sp")
   expect_error(make_map(type = "siple", map = testmap))
 })
 


### PR DESCRIPTION
There are packages in the DESCRIPTION file that are not used. This PR will remove those packages, so we do not have to install them when installing `shinymap`.